### PR TITLE
Bugfix for Uncaught SecurityError: Failed to execute 'texImage2D' on …

### DIFF
--- a/lib/three3d/loaders/ImageLoaderForWeb.dart
+++ b/lib/three3d/loaders/ImageLoaderForWeb.dart
@@ -8,6 +8,7 @@ class ImageLoaderLoader {
       {Function? imageDecoder}) {
     var completer = Completer<html.ImageElement>();
     var imageDom = html.ImageElement();
+    imageDom.crossOrigin = "";
 
     imageDom.onLoad.listen((e) {
       completer.complete(imageDom);


### PR DESCRIPTION
…'WebGLRenderingContext': The cross-origin image at path may not be loaded.