### PR TITLE
Fixes InstancedMesh related issues.

### DIFF
--- a/lib/three3d/math/Color.dart
+++ b/lib/three3d/math/Color.dart
@@ -716,8 +716,10 @@ class Color {
 
   /// dart array can not expand default
   /// so have to set array length enough first.
-  List<num> toArray([List<num>? array, int offset = 0]) {
-    array ??= List<num>.filled(3, 0.0);
+  // It's working, but ugly. consider to adds a new function: 
+  // toBufferAttribute(BufferAttribute attribute, int index) ???
+  toArray([array, int offset = 0]) {
+    array ??= List<double>.filled(3, 0.0);
 
     array[offset] = r;
     array[offset + 1] = g;

--- a/lib/three3d/objects/InstancedMesh.dart
+++ b/lib/three3d/objects/InstancedMesh.dart
@@ -80,11 +80,11 @@ class InstancedMesh extends Mesh {
     }
   }
 
-  List<num> setColorAt(int index, Color color) {
-    instanceColor ??= Float32BufferAttribute(
+  void setColorAt(int index, Color color) {
+    instanceColor ??= InstancedBufferAttribute(
         Float32Array((instanceMatrix!.count * 3).toInt()), 3, false);
 
-    return color.toArray(instanceColor!.array.data, index * 3);
+    return color.toArray(instanceColor!.array, index * 3);
   }
 
   void setMatrixAt(int index, Matrix4 matrix) {

--- a/lib/three3d/renderers/webgl/WebGLBufferRenderer.dart
+++ b/lib/three3d/renderers/webgl/WebGLBufferRenderer.dart
@@ -49,8 +49,7 @@ class WebGLBufferRenderer extends BaseWebGLBufferRenderer {
     var extension, methodName;
 
     if (isWebGL2) {
-      extension = gl;
-      methodName = 'drawArraysInstanced';
+	  gl.drawArraysInstanced(mode, start, count, primcount);
     } else {
       extension = extensions.get('ANGLE_instanced_arrays');
       methodName = 'drawArraysInstancedANGLE';
@@ -60,9 +59,9 @@ class WebGLBufferRenderer extends BaseWebGLBufferRenderer {
             'THREE.WebGLBufferRenderer: using THREE.InstancedBufferGeometry but hardware does not support extension ANGLE_instanced_arrays.');
         return;
       }
+      extension[methodName](mode, start, count, primcount);
     }
 
-    extension[methodName](mode, start, count, primcount);
 
     info.update(count, mode, primcount);
   }


### PR DESCRIPTION
Depends on flutter_gl pull request: https://github.com/wasabia/flutter_gl/pull/30

Test case: 
    final mat = MeshPhongMaterial();
    final geo = IcosahedronGeometry(0.5, 3); //BufferGeometry();
    final instancedMesh = InstancedMesh(geo, mat, count);
    final matrix = three.Matrix4();
    final color = Color.fromHex(0xff0000);
    for (int i = 0; i < count; i++) {
      double x = _random.nextDouble() * 600 - 300;
      double y = _random.nextDouble() * 800 - 300;
      matrix.setPosition(x, y, 0);
      instancedMesh.setMatrixAt(i, matrix);
      instancedMesh.setColorAt(i, color);
    }
    scene.add(instancedMesh);