### PR TITLE
Fixes a crash on sorting groupOrder and improves RenderItems sorting.

### DIFF
--- a/lib/three3d/core/Object3D.dart
+++ b/lib/three3d/core/Object3D.dart
@@ -49,7 +49,7 @@ class Object3D with EventDispatcher {
   bool receiveShadow = false;
 
   bool frustumCulled = true;
-  double renderOrder = 0.0;
+  int renderOrder = 0;
 
   // List<AnimationClip> animations = [];
 

--- a/lib/three3d/renderers/WebGLRenderer.dart
+++ b/lib/three3d/renderers/WebGLRenderer.dart
@@ -491,7 +491,8 @@ class WebGLRenderer {
     // print("renderBufferDirect - 0: ${DateTime.now().millisecondsSinceEpoch} - ${DateTime.now().microsecondsSinceEpoch}  ");
     BufferAttribute? index = geometry.index;
     BufferAttribute? position = geometry.attributes["position"];
-    // print(" WebGLRenderer.renderBufferDirect geometry.index ${index?.count} - ${index} position: ${position.count} - ${position}  ");
+    
+    // print(" WebGLRenderer.renderBufferDirect geometry.index ${index?.count} - ${index} position: - ${position}  ");
     if (index == null) {
       if (position == null || position.count == 0) return;
     } else if (index.count == 0) {
@@ -541,8 +542,6 @@ class WebGLRenderer {
 
     if (drawCount == 0) return;
 
-    //
-
     if (object is Mesh) {
       if (material.wireframe == true) {
         state
@@ -567,7 +566,7 @@ class WebGLRenderer {
       }
     } else if (object is Points) {
       renderer.setMode(_gl.POINTS);
-    } else if (object.type == "Sprite") {
+    } else if (object is Sprite) {
       renderer.setMode(_gl.TRIANGLES);
     }
 
@@ -955,8 +954,8 @@ class WebGLRenderer {
 
   void renderObject(Object3D object, scene, Camera camera,
       BufferGeometry geometry, Material material, Map<String, dynamic>? group) {
-    // print(" render renderObject  type: ${object.type} material: ${material} geometry: ${geometry}");
-    // print("1 render renderObject type: ${object.type} name: ${object.name} ${DateTime.now().millisecondsSinceEpoch}");
+    // print(" render renderObject  type: ${object.type} material: ${material} name: ${object.name}  geometry: ${geometry}");
+    // print("1 render renderObject type: ${object.type} name: ${object.name}  ${DateTime.now().millisecondsSinceEpoch}");
 
     if (object.onBeforeRender != null) {
       object.onBeforeRender!(
@@ -1359,8 +1358,7 @@ class WebGLRenderer {
           pUniforms.setValue(
               _gl, 'boneTextureSize', skeleton.boneTextureSize, textures);
         } else {
-          console.warn(
-              'THREE.WebGLRenderer: SkinnedMesh can only be used with WebGL 2. With WebGL 1 OES_texture_float and vertex textures support is required.');
+          console.warn( 'THREE.WebGLRenderer: SkinnedMesh can only be used with WebGL 2. With WebGL 1 OES_texture_float and vertex textures support is required.' );
         }
       }
     }
@@ -1642,6 +1640,7 @@ class WebGLRenderer {
           return;
         }
 
+        
         // the following if statement ensures valid read requests (no out-of-bounds pixels, see #8604)
 
         if ((x >= 0 && x <= (renderTarget.width - width)) &&
@@ -1651,6 +1650,7 @@ class WebGLRenderer {
           _gl.readPixels(x, y, width, height, utils.convert(textureFormat),
               utils.convert(textureType), buffer);
         }
+        
       } finally {
         var framebuffer = (_currentRenderTarget != null)
             ? properties.get(_currentRenderTarget)["__webglFramebuffer"]

--- a/lib/three3d/renderers/WebGLRenderer.dart
+++ b/lib/three3d/renderers/WebGLRenderer.dart
@@ -491,8 +491,7 @@ class WebGLRenderer {
     // print("renderBufferDirect - 0: ${DateTime.now().millisecondsSinceEpoch} - ${DateTime.now().microsecondsSinceEpoch}  ");
     BufferAttribute? index = geometry.index;
     BufferAttribute? position = geometry.attributes["position"];
-    
-    // print(" WebGLRenderer.renderBufferDirect geometry.index ${index?.count} - ${index} position: - ${position}  ");
+    // print(" WebGLRenderer.renderBufferDirect geometry.index ${index?.count} - ${index} position: ${position.count} - ${position}  ");
     if (index == null) {
       if (position == null || position.count == 0) return;
     } else if (index.count == 0) {
@@ -542,6 +541,8 @@ class WebGLRenderer {
 
     if (drawCount == 0) return;
 
+    //
+
     if (object is Mesh) {
       if (material.wireframe == true) {
         state
@@ -566,7 +567,7 @@ class WebGLRenderer {
       }
     } else if (object is Points) {
       renderer.setMode(_gl.POINTS);
-    } else if (object is Sprite) {
+    } else if (object.type == "Sprite") {
       renderer.setMode(_gl.TRIANGLES);
     }
 
@@ -755,7 +756,7 @@ class WebGLRenderer {
   }
 
   void projectObject(
-      Object3D object, Camera camera, double groupOrder, bool sortObjects) {
+      Object3D object, Camera camera, int groupOrder, bool sortObjects) {
     // print("projectObject object: ${object} name: ${object.name} tag: ${object.tag}  ${object.visible} ${object.scale.toJSON()} ${object.children.length}  ");
 
     if (object.visible == false) return;
@@ -954,8 +955,8 @@ class WebGLRenderer {
 
   void renderObject(Object3D object, scene, Camera camera,
       BufferGeometry geometry, Material material, Map<String, dynamic>? group) {
-    // print(" render renderObject  type: ${object.type} material: ${material} name: ${object.name}  geometry: ${geometry}");
-    // print("1 render renderObject type: ${object.type} name: ${object.name}  ${DateTime.now().millisecondsSinceEpoch}");
+    // print(" render renderObject  type: ${object.type} material: ${material} geometry: ${geometry}");
+    // print("1 render renderObject type: ${object.type} name: ${object.name} ${DateTime.now().millisecondsSinceEpoch}");
 
     if (object.onBeforeRender != null) {
       object.onBeforeRender!(
@@ -1358,7 +1359,8 @@ class WebGLRenderer {
           pUniforms.setValue(
               _gl, 'boneTextureSize', skeleton.boneTextureSize, textures);
         } else {
-          console.warn( 'THREE.WebGLRenderer: SkinnedMesh can only be used with WebGL 2. With WebGL 1 OES_texture_float and vertex textures support is required.' );
+          console.warn(
+              'THREE.WebGLRenderer: SkinnedMesh can only be used with WebGL 2. With WebGL 1 OES_texture_float and vertex textures support is required.');
         }
       }
     }
@@ -1640,7 +1642,6 @@ class WebGLRenderer {
           return;
         }
 
-        
         // the following if statement ensures valid read requests (no out-of-bounds pixels, see #8604)
 
         if ((x >= 0 && x <= (renderTarget.width - width)) &&
@@ -1650,7 +1651,6 @@ class WebGLRenderer {
           _gl.readPixels(x, y, width, height, utils.convert(textureFormat),
               utils.convert(textureType), buffer);
         }
-        
       } finally {
         var framebuffer = (_currentRenderTarget != null)
             ? properties.get(_currentRenderTarget)["__webglFramebuffer"]

--- a/lib/three3d/renderers/webgl/WebGLRenderList.dart
+++ b/lib/three3d/renderers/webgl/WebGLRenderList.dart
@@ -1,14 +1,14 @@
 part of three_webgl;
 
 class RenderItem {
-  num? id;
+  int id = 0;
   Object3D? object;
   BufferGeometry? geometry;
   Material? material;
   dynamic? program;
-  num? groupOrder;
-  num? renderOrder;
-  num? z;
+  int groupOrder = 0;
+  int renderOrder = 0;
+  double z = 0;
   Map<String, dynamic>? group;
 
   RenderItem(Map<String, dynamic> json) {
@@ -47,7 +47,7 @@ class WebGLRenderList {
   WebGLRenderList();
 
   Map<int, RenderItem> renderItems = {};
-  var renderItemsIndex = 0;
+  int renderItemsIndex = 0;
 
   List<RenderItem> opaque = [];
   List<RenderItem> transmissive = [];
@@ -63,8 +63,13 @@ class WebGLRenderList {
     transparent.length = 0;
   }
 
-  RenderItem getNextRenderItem(Object3D object, BufferGeometry? geometry,
-      Material? material, double groupOrder, num z, Map<String, dynamic>? group) {
+  RenderItem getNextRenderItem(
+      Object3D object,
+      BufferGeometry? geometry,
+      Material? material,
+      int groupOrder,
+      double z,
+      Map<String, dynamic>? group) {
     var renderItem = renderItems[renderItemsIndex];
 
     if (renderItem == null) {
@@ -96,8 +101,8 @@ class WebGLRenderList {
     return renderItem;
   }
 
-  void push(Object3D object, BufferGeometry geometry, material, double groupOrder,
-      num z, Map<String, dynamic>? group) {
+  void push(Object3D object, BufferGeometry geometry, material, int groupOrder,
+      double z, Map<String, dynamic>? group) {
     var renderItem =
         getNextRenderItem(object, geometry, material, groupOrder, z, group);
 
@@ -113,7 +118,7 @@ class WebGLRenderList {
   }
 
   void unshift(Object3D object, BufferGeometry? geometry, Material material,
-      double groupOrder, num z, Map<String, dynamic>? group) {
+      int groupOrder, double z, Map<String, dynamic>? group) {
     var renderItem =
         getNextRenderItem(object, geometry, material, groupOrder, z, group);
 
@@ -128,7 +133,7 @@ class WebGLRenderList {
     }
   }
 
-  sort(customOpaqueSort, customTransparentSort) {
+  void sort(customOpaqueSort, customTransparentSort) {
     if (opaque.length > 1) {
       opaque.sort(customOpaqueSort ?? painterSortStable);
     }
@@ -142,15 +147,15 @@ class WebGLRenderList {
     }
   }
 
-  finish() {
+  void finish() {
     // Clear references from inactive renderItems in the list
 
     for (var i = renderItemsIndex, il = renderItems.length; i < il; i++) {
       var renderItem = renderItems[i]!;
 
-      if (renderItem.id == null) break;
+      if (renderItem.id == 0) break;
 
-      renderItem.id = null;
+      renderItem.id = 0;
       renderItem.object = null;
       renderItem.geometry = null;
       renderItem.material = null;
@@ -159,7 +164,7 @@ class WebGLRenderList {
     }
   }
 
-  int painterSortStable(a, b) {
+  int painterSortStable(RenderItem a, RenderItem b) {
     if (a.groupOrder != b.groupOrder) {
       return a.groupOrder - b.groupOrder;
     } else if (a.renderOrder != b.renderOrder) {
@@ -175,13 +180,13 @@ class WebGLRenderList {
     }
   }
 
-  int reversePainterSortStable(a, b) {
+  int reversePainterSortStable(RenderItem a, RenderItem b) {
     // print("3 reversePainterSortStable ${a.id} ${b.id} ");
 
     if (a.groupOrder != b.groupOrder) {
       return a.groupOrder - b.groupOrder;
     } else if (a.renderOrder != b.renderOrder) {
-      return (a.renderOrder - b.renderOrder).toInt();
+      return a.renderOrder - b.renderOrder;
     } else if (a.z != b.z) {
       final _v = b.z - a.z;
       return _v > 0 ? 1 : -1;


### PR DESCRIPTION
When specified a non-zero number to Group.renderOrder, the engine will be crashed on sorting RenderItems.

To fix this issue, changes the variable type from num to int for RenderItem[ id, groupOrder, renderOrder ], num to double for Object3D [ z ].

