### PR TITLE
fix: #91 - Add material clone case for when an object has a list

### DIFF
--- a/lib/three3d/materials/MeshPhongMaterial.dart
+++ b/lib/three3d/materials/MeshPhongMaterial.dart
@@ -49,6 +49,11 @@ class MeshPhongMaterial extends Material {
   }
 
   @override
+  MeshPhongMaterial clone() {
+    return MeshPhongMaterial().copy(this);
+  }
+
+  @override
   MeshPhongMaterial copy(Material source) {
     super.copy(source);
 

--- a/lib/three3d/objects/Mesh.dart
+++ b/lib/three3d/objects/Mesh.dart
@@ -38,7 +38,15 @@ class Mesh extends Object3D {
 
   @override
   Mesh clone([bool? recursive = true]) {
-    return Mesh(geometry!.clone(), material.clone()).copy(this, recursive);
+    final materials = <Material>[];
+
+    if (material is Material) {
+      materials.add((material as Material).clone());
+    } else if (material is Iterable) {
+      materials.addAll((material as Iterable).map((e) => (e as Material).clone()));
+    }
+
+    return Mesh(geometry!.clone(), materials).copy(this, recursive);
   }
 
   @override


### PR DESCRIPTION
- Added is Iterable check to materials clone in Mesh
- Added missing MeshPhongMaterial .clone method