### PR TITLE
Fix lints and properly dispose NativeArrays when Object3d's and Buffergeometry gets dispose 

### DIFF
--- a/example/lib/webgl_debug_for_macos.dart
+++ b/example/lib/webgl_debug_for_macos.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -11,8 +10,7 @@ import 'package:three_dart/three_dart.dart' as three;
 class WebGlDebugForMacos extends StatefulWidget {
   final String fileName;
 
-  const WebGlDebugForMacos({Key? key, required this.fileName})
-      : super(key: key);
+  const WebGlDebugForMacos({Key? key, required this.fileName}) : super(key: key);
 
   @override
   State<WebGlDebugForMacos> createState() => _MyAppState();
@@ -138,13 +136,10 @@ class _MyAppState extends State<WebGlDebugForMacos> {
                 child: Builder(builder: (BuildContext context) {
                   if (kIsWeb) {
                     return three3dRender.isInitialized
-                        ? HtmlElementView(
-                            viewType: three3dRender.textureId!.toString())
+                        ? HtmlElementView(viewType: three3dRender.textureId!.toString())
                         : Container();
                   } else {
-                    return three3dRender.isInitialized
-                        ? Texture(textureId: three3dRender.textureId!)
-                        : Container();
+                    return three3dRender.isInitialized ? Texture(textureId: three3dRender.textureId!) : Container();
                   }
                 })),
           ],
@@ -221,13 +216,9 @@ class _MyAppState extends State<WebGlDebugForMacos> {
     renderer!.shadowMap.type = three.BasicShadowMap;
 
     if (!kIsWeb) {
-      var pars = three.WebGLRenderTargetOptions({
-        "minFilter": three.LinearFilter,
-        "magFilter": three.LinearFilter,
-        "format": three.RGBAFormat
-      });
-      renderTarget = three.WebGLMultisampleRenderTarget(
-          (width * dpr).toInt(), (height * dpr).toInt(), pars);
+      var pars = three.WebGLRenderTargetOptions(
+          {"minFilter": three.LinearFilter, "magFilter": three.LinearFilter, "format": three.RGBAFormat});
+      renderTarget = three.WebGLMultisampleRenderTarget((width * dpr).toInt(), (height * dpr).toInt(), pars);
       renderer!.setRenderTarget(renderTarget);
       sourceTexture = renderer!.getRenderTargetGLTexture(renderTarget);
     }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.0"
   convert:
     dependency: transitive
     description:
@@ -204,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.6.5"
   lints:
     dependency: transitive
     description:
@@ -220,10 +220,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.14"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
@@ -252,10 +252,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.8.2"
   petitparser:
     dependency: transitive
     description:
@@ -329,10 +329,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.4.16"
   three_dart:
     dependency: "direct main"
     description:
@@ -397,5 +397,5 @@ packages:
     source: hosted
     version: "6.2.2"
 sdks:
-  dart: ">=2.19.0 <4.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.0.1"

--- a/lib/three3d/animation/keyframe_track.dart
+++ b/lib/three3d/animation/keyframe_track.dart
@@ -105,7 +105,6 @@ class KeyframeTrack {
           setInterpolation(defaultInterpolation);
         } else {
           throw (message); // fatal, in this case
-
         }
       }
 
@@ -208,14 +207,14 @@ class KeyframeTrack {
 
     var valueSize = getValueSize();
     if (valueSize - Math.floor(valueSize) != 0) {
-      print('three.KeyframeTrack: Invalid value size in track. ${this}');
+      print('three.KeyframeTrack: Invalid value size in track. $this');
       valid = false;
     }
 
     var times = this.times, nKeys = times.length;
 
     if (nKeys == 0) {
-      print('three.KeyframeTrack: Track is empty. ${this}');
+      print('three.KeyframeTrack: Track is empty. $this');
       valid = false;
     }
 
@@ -225,7 +224,7 @@ class KeyframeTrack {
       var currTime = times[i];
 
       if (prevTime != null && prevTime > currTime) {
-        print('three.KeyframeTrack: Out of order keys.${this} i: $i currTime: $currTime prevTime: $prevTime');
+        print('three.KeyframeTrack: Out of order keys. $this i: $i currTime: $currTime prevTime: $prevTime');
         valid = false;
         break;
       }

--- a/lib/three3d/animation/property_binding.dart
+++ b/lib/three3d/animation/property_binding.dart
@@ -442,13 +442,13 @@ class PropertyBinding {
       switch (objectName) {
         case 'materials':
           if (!targetObject.material) {
-            print('three.PropertyBinding: Can not bind to material as node does not have a material. ${this}');
+            print('three.PropertyBinding: Can not bind to material as node does not have a material. $this');
             return;
           }
 
           if (!targetObject.material.materials) {
             print(
-                'three.PropertyBinding: Can not bind to material.materials as node.material does not have a materials array. ${this}');
+                'three.PropertyBinding: Can not bind to material.materials as node.material does not have a materials array. $this');
             return;
           }
 
@@ -458,7 +458,7 @@ class PropertyBinding {
 
         case 'bones':
           if (!targetObject.skeleton) {
-            print('three.PropertyBinding: Can not bind to bones as node does not have a skeleton. ${this}');
+            print('three.PropertyBinding: Can not bind to bones as node does not have a skeleton. $this');
             return;
           }
 
@@ -479,7 +479,7 @@ class PropertyBinding {
 
         default:
           if (targetObject.getProperty(objectName) == null) {
-            print('three.PropertyBinding: Can not bind to objectName of node null. ${this}');
+            print('three.PropertyBinding: Can not bind to objectName of node null. $this');
             return;
           }
 
@@ -489,8 +489,7 @@ class PropertyBinding {
 
       if (objectIndex != null) {
         if (targetObject[objectIndex] == null) {
-          print(
-              'three.PropertyBinding: Trying to bind to objectIndex of objectName, but is null.${this} $targetObject');
+          print('three.PropertyBinding: Trying to bind to objectIndex of objectName, but is null.$this $targetObject');
           return;
         }
 
@@ -535,14 +534,14 @@ class PropertyBinding {
         // support resolving morphTarget names into indices.
         if (!targetObject.geometry) {
           print(
-              'three.PropertyBinding: Can not bind to morphTargetInfluences because node does not have a geometry. ${this}');
+              'three.PropertyBinding: Can not bind to morphTargetInfluences because node does not have a geometry. $this');
           return;
         }
 
         if (targetObject.geometry is BufferGeometry) {
           if (!targetObject.geometry.morphAttributes) {
             print(
-                'three.PropertyBinding: Can not bind to morphTargetInfluences because node does not have a geometry.morphAttributes. ${this}');
+                'three.PropertyBinding: Can not bind to morphTargetInfluences because node does not have a geometry.morphAttributes. $this');
             return;
           }
 
@@ -551,7 +550,7 @@ class PropertyBinding {
           }
         } else {
           print(
-              'three.PropertyBinding: Can not bind to morphTargetInfluences on three.Geometry. Use three.BufferGeometry instead. ${this}');
+              'three.PropertyBinding: Can not bind to morphTargetInfluences on three.Geometry. Use three.BufferGeometry instead. $this');
           return;
         }
       }

--- a/lib/three3d/core/buffer_geometry.dart
+++ b/lib/three3d/core/buffer_geometry.dart
@@ -57,6 +57,8 @@ class BufferGeometry with EventDispatcher {
   int? maxInstanceCount;
   int? instanceCount;
 
+  Float32Array? array;
+
   BufferGeometry();
 
   BufferGeometry.fromJSON(Map<String, dynamic> json, Map<String, dynamic> rootJSON) {
@@ -268,8 +270,9 @@ class BufferGeometry with EventDispatcher {
       }
     }
 
-    final array = Float32Array.from(position);
-    setAttribute('position', Float32BufferAttribute(array, 3, false));
+    array?.dispose();
+    array = Float32Array.from(position);
+    setAttribute('position', Float32BufferAttribute(array!, 3, false));
 
     return this;
   }
@@ -947,6 +950,23 @@ class BufferGeometry with EventDispatcher {
     print(" BufferGeometry dispose ........... ");
 
     dispatchEvent(Event({"type": "dispose"}));
+
+    if (attributes["color"] is BufferAttribute) {
+      (attributes["color"] as BufferAttribute).array.dispose();
+    }
+    if (attributes["position"] is BufferAttribute) {
+      (attributes["position"] as BufferAttribute).array.dispose();
+    }
+
+    if (attributes["normal"] is BufferAttribute) {
+      (attributes["normal"] as BufferAttribute).array.dispose();
+    }
+    if (attributes["uv"] is BufferAttribute) {
+      (attributes["uv"] as BufferAttribute).array.dispose();
+    }
+
+    index?.array.dispose();
+    array?.dispose();
   }
 }
 

--- a/lib/three3d/core/buffer_geometry.dart
+++ b/lib/three3d/core/buffer_geometry.dart
@@ -282,7 +282,7 @@ class BufferGeometry with EventDispatcher {
 
     if (position != null && position is GLBufferAttribute) {
       print(
-          'three.BufferGeometry.computeBoundingBox(): GLBufferAttribute requires a manual bounding box. Alternatively set "mesh.frustumCulled" to "false". ${this}');
+          'three.BufferGeometry.computeBoundingBox(): GLBufferAttribute requires a manual bounding box. Alternatively set "mesh.frustumCulled" to "false". $this');
 
       double inf = 9999999999.0;
 
@@ -404,7 +404,7 @@ class BufferGeometry with EventDispatcher {
 
       if (boundingSphere?.radius == null) {
         print(
-            'three.BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The "position" attribute is likely to have NaN values. ${this}');
+            'three.BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The "position" attribute is likely to have NaN values. $this');
       }
     }
   }

--- a/lib/three3d/core/object_3d.dart
+++ b/lib/three3d/core/object_3d.dart
@@ -877,7 +877,13 @@ class Object3D with EventDispatcher {
     }
   }
 
-  void dispose() {}
+  void dispose() {
+    matrix?.dispose();
+    matrixWorld?.dispose();
+    modelViewMatrix?.dispose();
+    normalMatrix?.dispose();
+    bindMatrix?.dispose();
+  }
 }
 
 class Object3dMeta {

--- a/lib/three3d/extras/core/curve.dart
+++ b/lib/three3d/extras/core/curve.dart
@@ -199,7 +199,6 @@ class Curve {
         break;
 
         // DONE
-
       }
     }
 
@@ -343,6 +342,8 @@ class Curve {
         binormals[i].crossVectors(tangents[i], normals[i]);
       }
     }
+
+    mat.dispose();
 
     return {"tangents": tangents, "normals": normals, "binormals": binormals};
   }

--- a/lib/three3d/extras/pmrem_generator.dart
+++ b/lib/three3d/extras/pmrem_generator.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_gl/flutter_gl.dart';
@@ -184,11 +183,8 @@ class PMREMGenerator {
   }
 
   _fromTexture(texture, [renderTarget]) {
-    if (texture.mapping == CubeReflectionMapping ||
-        texture.mapping == CubeRefractionMapping) {
-      _setSize(texture.image.length == 0
-          ? 16
-          : (texture.image[0].width ?? texture.image[0].image.width));
+    if (texture.mapping == CubeReflectionMapping || texture.mapping == CubeRefractionMapping) {
+      _setSize(texture.image.length == 0 ? 16 : (texture.image[0].width ?? texture.image[0].image.width));
     } else {
       // Equirectangular
 
@@ -296,8 +292,7 @@ class PMREMGenerator {
         cubeCamera.lookAt(Vector3(0, 0, forwardSign[i]));
       }
       var size = _cubeSize;
-      _setViewport(
-          cubeUVRenderTarget, col * size, i > 2 ? size : 0, size, size);
+      _setViewport(cubeUVRenderTarget, col * size, i > 2 ? size : 0, size, size);
       renderer.setRenderTarget(cubeUVRenderTarget);
       if (useSolidColor) {
         renderer.render(backgroundBox, cubeCamera);
@@ -315,14 +310,12 @@ class PMREMGenerator {
   _textureToCubeUV(texture, cubeUVRenderTarget) {
     var renderer = _renderer;
 
-    bool isCubeTexture = (texture.mapping == CubeReflectionMapping ||
-        texture.mapping == CubeRefractionMapping);
+    bool isCubeTexture = (texture.mapping == CubeReflectionMapping || texture.mapping == CubeRefractionMapping);
 
     if (isCubeTexture) {
       _cubemapMaterial ??= _getCubemapShader();
 
-      _cubemapMaterial.uniforms["flipEnvMap"]["value"] =
-          (texture.isRenderTargetTexture == false) ? -1 : 1;
+      _cubemapMaterial.uniforms["flipEnvMap"]["value"] = (texture.isRenderTargetTexture == false) ? -1 : 1;
     } else {
       _equirectMaterial ??= _getEquirectMaterial();
     }
@@ -352,8 +345,7 @@ class PMREMGenerator {
     renderer.autoClear = false;
 
     for (var i = 1; i < _lodPlanes.length; i++) {
-      var sigma =
-          Math.sqrt(_sigmas[i] * _sigmas[i] - _sigmas[i - 1] * _sigmas[i - 1]);
+      var sigma = Math.sqrt(_sigmas[i] * _sigmas[i] - _sigmas[i - 1] * _sigmas[i - 1]);
 
       var poleAxis = _axisDirections[(i - 1) % _axisDirections.length];
 
@@ -421,13 +413,9 @@ class PMREMGenerator {
     var blurUniforms = blurMaterial.uniforms;
 
     var pixels = _sizeLods[lodIn] - 1;
-    var radiansPerPixel = isFinite(sigmaRadians)
-        ? Math.pi / (2 * pixels)
-        : 2 * Math.pi / (2 * maxSamples - 1);
+    var radiansPerPixel = isFinite(sigmaRadians) ? Math.pi / (2 * pixels) : 2 * Math.pi / (2 * maxSamples - 1);
     var sigmaPixels = sigmaRadians / radiansPerPixel;
-    var samples = isFinite(sigmaRadians)
-        ? 1 + Math.floor(stddev * sigmaPixels)
-        : maxSamples;
+    var samples = isFinite(sigmaRadians) ? 1 + Math.floor(stddev * sigmaPixels) : maxSamples;
 
     if (samples > maxSamples) {
       print(
@@ -466,9 +454,7 @@ class PMREMGenerator {
     blurUniforms['mipInt']["value"] = _lodMax - lodIn;
 
     var outputSize = _sizeLods[lodOut];
-    var x = 3 *
-        outputSize *
-        (lodOut > _lodMax - lodMin ? lodOut - _lodMax + lodMin : 0);
+    var x = 3 * outputSize * (lodOut > _lodMax - lodMin ? lodOut - _lodMax + lodMin : 0);
     var y = 4 * (_cubeSize - outputSize);
 
     _setViewport(targetOut, x, y, 3 * outputSize, 2 * outputSize);
@@ -554,11 +540,9 @@ class PMREMGenerator {
       }
 
       var planes = BufferGeometry();
-      planes.setAttribute(
-          'position', Float32BufferAttribute(position, positionSize, false));
+      planes.setAttribute('position', Float32BufferAttribute(position, positionSize, false));
       planes.setAttribute('uv', Float32BufferAttribute(uv, uvSize, false));
-      planes.setAttribute(
-          'faceIndex', Float32BufferAttribute(faceIndex, faceIndexSize, false));
+      planes.setAttribute('faceIndex', Float32BufferAttribute(faceIndex, faceIndexSize, false));
       lodPlanes.add(planes);
 
       if (lod > lodMin) {
@@ -570,8 +554,7 @@ class PMREMGenerator {
   }
 
   _createRenderTarget(int width, int height, params) {
-    var cubeUVRenderTarget =
-        WebGLRenderTarget(width, height, WebGLRenderTargetOptions(params));
+    var cubeUVRenderTarget = WebGLRenderTarget(width, height, WebGLRenderTargetOptions(params));
     cubeUVRenderTarget.texture.mapping = CubeUVReflectionMapping;
     cubeUVRenderTarget.texture.name = 'PMREM.cubeUv';
     cubeUVRenderTarget.scissorTest = true;

--- a/lib/three3d/geometries/box_geometry.dart
+++ b/lib/three3d/geometries/box_geometry.dart
@@ -6,6 +6,10 @@ class BoxGeometry extends BufferGeometry {
   late int groupStart;
   late int numberOfVertices;
 
+  NativeArray? positionsArray;
+  NativeArray? normalsArray;
+  NativeArray? uvsArray;
+
   BoxGeometry([
     width = 1,
     height = 1,
@@ -170,9 +174,9 @@ class BoxGeometry extends BufferGeometry {
     // build geometry
 
     setIndex(indices);
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3, false));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3, false));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvs), 2, false));
+    setAttribute('position', Float32BufferAttribute(positionsArray = Float32Array.from(vertices), 3, false));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3, false));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvs), 2, false));
   }
 
   static fromJSON(data) {
@@ -184,5 +188,14 @@ class BoxGeometry extends BufferGeometry {
       data["heightSegments"],
       data["depthSegments"],
     );
+  }
+
+  @override
+  void dispose() {
+    positionsArray?.dispose();
+    normalsArray?.dispose();
+    uvsArray?.dispose();
+
+    super.dispose();
   }
 }

--- a/lib/three3d/geometries/circle_geometry.dart
+++ b/lib/three3d/geometries/circle_geometry.dart
@@ -3,6 +3,10 @@ import 'package:three_dart/three3d/core/index.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class CircleGeometry extends BufferGeometry {
+  NativeArray? positionsArray;
+  NativeArray? normalsArray;
+  NativeArray? uvsArray;
+
   CircleGeometry({radius = 1, segments = 8, thetaStart = 0, thetaLength = Math.pi * 2}) : super() {
     type = 'CircleGeometry';
 
@@ -59,8 +63,17 @@ class CircleGeometry extends BufferGeometry {
     // build geometry
 
     setIndex(indices);
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3, false));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3, false));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvs), 2, false));
+    setAttribute('position', Float32BufferAttribute(positionsArray = Float32Array.from(vertices), 3, false));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3, false));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvs), 2, false));
+  }
+
+  @override
+  void dispose() {
+    positionsArray?.dispose();
+    normalsArray?.dispose();
+    uvsArray?.dispose();
+
+    super.dispose();
   }
 }

--- a/lib/three3d/geometries/convex_geometry.dart
+++ b/lib/three3d/geometries/convex_geometry.dart
@@ -3,6 +3,9 @@ import 'package:three_dart/three3d/core/index.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class ConvexGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+  NativeArray? normalsArray;
+
   ConvexGeometry(points) : super() {
     List<double> vertices = [];
     List<double> normals = [];
@@ -32,8 +35,15 @@ class ConvexGeometry extends BufferGeometry {
     }
 
     // build geometry
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3, false));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3, false));
+  }
 
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3, false));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3, false));
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    normalsArray?.dispose();
+
+    super.dispose();
   }
 }

--- a/lib/three3d/geometries/cylinder_geometry.dart
+++ b/lib/three3d/geometries/cylinder_geometry.dart
@@ -3,6 +3,10 @@ import 'package:three_dart/three3d/core/index.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class CylinderGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+  NativeArray? normalsArray;
+  NativeArray? uvsArray;
+
   CylinderGeometry([
     radiusTop = 1,
     radiusBottom = 1,
@@ -237,9 +241,9 @@ class CylinderGeometry extends BufferGeometry {
     // build geometry
 
     setIndex(indices);
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3, false));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3, false));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvs), 2, false));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3, false));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3, false));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvs), 2, false));
   }
 
   static CylinderGeometry fromJSON(data) {
@@ -253,5 +257,13 @@ class CylinderGeometry extends BufferGeometry {
       data["thetaStart"],
       data["thetaLength"],
     );
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    normalsArray?.dispose();
+    uvsArray?.dispose();
+    super.dispose();
   }
 }

--- a/lib/three3d/geometries/edges_geometry.dart
+++ b/lib/three3d/geometries/edges_geometry.dart
@@ -8,6 +8,8 @@ class EdgesGeometry extends BufferGeometry {
   final _normal = Vector3.init();
   final _triangle = Triangle.init();
 
+  NativeArray? verticesArray;
+
   EdgesGeometry(BufferGeometry geometry, thresholdAngle) : super() {
     type = "EdgesGeometry";
     parameters = {"thresholdAngle": thresholdAngle};
@@ -102,6 +104,12 @@ class EdgesGeometry extends BufferGeometry {
       }
     }
 
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3, false));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3, false));
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    super.dispose();
   }
 }

--- a/lib/three3d/geometries/extrude_geometry.dart
+++ b/lib/three3d/geometries/extrude_geometry.dart
@@ -529,9 +529,12 @@ class ExtrudeGeometry extends BufferGeometry {
     }
 
     // build geometry
+    final nativeVertices = Float32Array.from(verticesArray);
+    final nativeUv = Float32Array.from(uvArray);
+    arrays.addAll([nativeVertices, nativeUv]);
 
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(verticesArray), 3, false));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvArray), 2, false));
+    setAttribute('position', Float32BufferAttribute(nativeVertices, 3, false));
+    setAttribute('uv', Float32BufferAttribute(nativeUv, 2, false));
 
     computeVertexNormals();
 
@@ -548,6 +551,16 @@ class ExtrudeGeometry extends BufferGeometry {
     var options = parameters?["options"];
 
     return toJSON2(shapes, options, data);
+  }
+
+  final arrays = <NativeArray>[];
+
+  @override
+  void dispose() {
+    for (var element in arrays) {
+      element.dispose();
+    }
+    super.dispose();
   }
 }
 

--- a/lib/three3d/geometries/lathe_geometry.dart
+++ b/lib/three3d/geometries/lathe_geometry.dart
@@ -3,6 +3,10 @@ import 'package:three_dart/three3d/core/index.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class LatheGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+  NativeArray? uvsArray;
+  NativeArray? normalsArray;
+
   LatheGeometry(
     points, {
     segments = 12,
@@ -142,8 +146,17 @@ class LatheGeometry extends BufferGeometry {
     // build geometry
 
     setIndex(indices);
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3, false));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvs), 2, false));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3, false));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3, false));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3, false));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvs), 2, false));
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    uvsArray?.dispose();
+    normalsArray?.dispose();
+
+    super.dispose();
   }
 }

--- a/lib/three3d/geometries/parametric_geometry.dart
+++ b/lib/three3d/geometries/parametric_geometry.dart
@@ -3,6 +3,10 @@ import 'package:three_dart/three3d/core/index.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class ParametricGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+  NativeArray? uvsArray;
+  NativeArray? normalsArray;
+
   ParametricGeometry(func, slices, stacks) : super() {
     type = "ParametricGeometry";
     parameters = {"func": func, "slices": slices, "stacks": stacks};
@@ -91,8 +95,17 @@ class ParametricGeometry extends BufferGeometry {
     // build geometry
 
     setIndex(indices);
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvs), 2));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvs), 2));
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    uvsArray?.dispose();
+    normalsArray?.dispose();
+
+    super.dispose();
   }
 }

--- a/lib/three3d/geometries/plane_geometry.dart
+++ b/lib/three3d/geometries/plane_geometry.dart
@@ -3,6 +3,10 @@ import 'package:three_dart/three3d/core/index.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class PlaneGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+  NativeArray? normalsArray;
+  NativeArray? uvsArray;
+
   PlaneGeometry([num width = 1, num height = 1, num widthSegments = 1, num heightSegments = 1]) : super() {
     type = 'PlaneGeometry';
 
@@ -55,12 +59,20 @@ class PlaneGeometry extends BufferGeometry {
     }
 
     setIndex(indices);
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3, false));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3, false));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvs), 2, false));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3, false));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3, false));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvs), 2, false));
   }
 
   static fromJSON(data) {
     return PlaneGeometry(data["width"], data["height"], data["widthSegments"], data["heightSegments"]);
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    normalsArray?.dispose();
+    uvsArray?.dispose();
+    super.dispose();
   }
 }

--- a/lib/three3d/geometries/polyhedron_geometry.dart
+++ b/lib/three3d/geometries/polyhedron_geometry.dart
@@ -4,6 +4,10 @@ import 'package:three_dart/three3d/dart_helpers.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class PolyhedronGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+  NativeArray? normalsArray;
+  NativeArray? uvsArray;
+
   PolyhedronGeometry(vertices, indices, [radius = 1, detail = 0]) : super() {
     type = "PolyhedronGeometry";
     // default buffer data
@@ -217,16 +221,24 @@ class PolyhedronGeometry extends BufferGeometry {
 
     // build non-indexed geometry
 
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertexBuffer), 3, false));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(slice<double>(vertexBuffer, 0)), 3, false));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvBuffer), 2, false));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertexBuffer), 3, false));
+    setAttribute(
+        'normal', Float32BufferAttribute(normalsArray = Float32Array.from(slice<double>(vertexBuffer, 0)), 3, false));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvBuffer), 2, false));
 
     if (detail == 0) {
       computeVertexNormals(); // flat normals
-
     } else {
       normalizeNormals(); // smooth normals
-
     }
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    normalsArray?.dispose();
+    uvsArray?.dispose();
+
+    super.dispose();
   }
 }

--- a/lib/three3d/geometries/ring_geometry.dart
+++ b/lib/three3d/geometries/ring_geometry.dart
@@ -3,6 +3,10 @@ import 'package:three_dart/three3d/core/index.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class RingGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+  NativeArray? normalsArray;
+  NativeArray? uvsArray;
+
   RingGeometry([
     innerRadius = 0.5,
     outerRadius = 1,
@@ -93,13 +97,22 @@ class RingGeometry extends BufferGeometry {
     // build geometry
 
     setIndex(indices);
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvs), 2));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvs), 2));
   }
 
   static fromJSON(data) {
     return RingGeometry(
         data.innerRadius, data.outerRadius, data.thetaSegments, data.phiSegments, data.thetaStart, data.thetaLength);
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    normalsArray?.dispose();
+    uvsArray?.dispose();
+
+    super.dispose();
   }
 }

--- a/lib/three3d/geometries/shape_geometry.dart
+++ b/lib/three3d/geometries/shape_geometry.dart
@@ -3,6 +3,10 @@ import 'package:three_dart/three3d/core/index.dart';
 import 'package:three_dart/three3d/extras/index.dart';
 
 class ShapeGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+  NativeArray? normalsArray;
+  NativeArray? uvsArray;
+
   ShapeGeometry(shapes, {num curveSegments = 12}) : super() {
     type = 'ShapeGeometry';
     parameters = {};
@@ -93,7 +97,6 @@ class ShapeGeometry extends BufferGeometry {
         vertices.addAll([vertex.x.toDouble(), vertex.y.toDouble(), 0.0]);
         normals.addAll([0.0, 0.0, 1.0]);
         uvs.addAll([vertex.x.toDouble(), vertex.y.toDouble()]); // world uvs
-
       }
 
       // incides
@@ -135,11 +138,19 @@ class ShapeGeometry extends BufferGeometry {
     // build geometry
 
     setIndex(indices);
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3, false));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3, false));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvs), 2, false));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3, false));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3, false));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvs), 2, false));
 
     // helper functions
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    normalsArray?.dispose();
+    uvsArray?.dispose();
+    super.dispose();
   }
 
   // addShape( List<num> vertices, List<num> normals, List<num> uvs, shape, groupCount ) {

--- a/lib/three3d/geometries/sphere_geometry.dart
+++ b/lib/three3d/geometries/sphere_geometry.dart
@@ -3,6 +3,10 @@ import 'package:three_dart/three3d/core/index.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class SphereGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+  NativeArray? normalsArray;
+  NativeArray? uvsArray;
+
   SphereGeometry([
     radius = 1,
     num widthSegments = 32,
@@ -103,9 +107,17 @@ class SphereGeometry extends BufferGeometry {
     // build geometry
 
     setIndex(indices);
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3, false));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3, false));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvs), 2, false));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3, false));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3, false));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvs), 2, false));
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    normalsArray?.dispose();
+    uvsArray?.dispose();
+    super.dispose();
   }
 
   static fromJSON(data) {

--- a/lib/three3d/geometries/torus_geometry.dart
+++ b/lib/three3d/geometries/torus_geometry.dart
@@ -3,6 +3,10 @@ import 'package:three_dart/three3d/core/index.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class TorusGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+  NativeArray? normalsArray;
+  NativeArray? uvsArray;
+
   TorusGeometry([
     radius = 1,
     tube = 0.4,
@@ -86,9 +90,17 @@ class TorusGeometry extends BufferGeometry {
     // build geometry
 
     setIndex(indices);
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvs), 2));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvs), 2));
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    normalsArray?.dispose();
+    uvsArray?.dispose();
+    super.dispose();
   }
 
   static fromJSON(data) {

--- a/lib/three3d/geometries/torus_knot_geometry.dart
+++ b/lib/three3d/geometries/torus_knot_geometry.dart
@@ -3,6 +3,10 @@ import 'package:three_dart/three3d/core/index.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class TorusKnotGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+  NativeArray? normalsArray;
+  NativeArray? uvsArray;
+
   TorusKnotGeometry([
     double radius = 1,
     double tube = 0.4,
@@ -130,10 +134,18 @@ class TorusKnotGeometry extends BufferGeometry {
     // build geometry
 
     setIndex(indices);
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3, false));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3, false));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvs), 2, false));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3, false));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3, false));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvs), 2, false));
 
     // this function calculates the current position on the torus curve
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    normalsArray?.dispose();
+    uvsArray?.dispose();
+    super.dispose();
   }
 }

--- a/lib/three3d/geometries/tube_geometry.dart
+++ b/lib/three3d/geometries/tube_geometry.dart
@@ -4,6 +4,10 @@ import 'package:three_dart/three3d/extras/curves/quadratic_bezier_curve.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class TubeGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+  NativeArray? normalsArray;
+  NativeArray? uvsArray;
+
   TubeGeometry([
     curve,
     tubularSegments = 64,
@@ -116,8 +120,16 @@ class TubeGeometry extends BufferGeometry {
     generateBufferData();
 
     setIndex(indices);
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3, false));
-    setAttribute('normal', Float32BufferAttribute(Float32Array.from(normals), 3, false));
-    setAttribute('uv', Float32BufferAttribute(Float32Array.from(uvs), 2, false));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3, false));
+    setAttribute('normal', Float32BufferAttribute(normalsArray = Float32Array.from(normals), 3, false));
+    setAttribute('uv', Float32BufferAttribute(uvsArray = Float32Array.from(uvs), 2, false));
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    normalsArray?.dispose();
+    uvsArray?.dispose();
+    super.dispose();
   }
 }

--- a/lib/three3d/geometries/wireframe_geometry.dart
+++ b/lib/three3d/geometries/wireframe_geometry.dart
@@ -3,6 +3,8 @@ import 'package:three_dart/three3d/core/index.dart';
 import 'package:three_dart/three3d/math/index.dart';
 
 class WireframeGeometry extends BufferGeometry {
+  NativeArray? verticesArray;
+
   WireframeGeometry(BufferGeometry geometry) : super() {
     type = "WireframeGeometry";
     // buffer
@@ -77,7 +79,13 @@ class WireframeGeometry extends BufferGeometry {
 
     // build geometry
 
-    setAttribute('position', Float32BufferAttribute(Float32Array.from(vertices), 3, false));
+    setAttribute('position', Float32BufferAttribute(verticesArray = Float32Array.from(vertices), 3, false));
+  }
+
+  @override
+  void dispose() {
+    verticesArray?.dispose();
+    super.dispose();
   }
 }
 

--- a/lib/three3d/helpers/arrow_helper.dart
+++ b/lib/three3d/helpers/arrow_helper.dart
@@ -13,6 +13,8 @@ class ArrowHelper extends Object3D {
   late Line line;
   late Mesh cone;
 
+  NativeArray? positionArray;
+
   ArrowHelper(dir, origin, length, color, headLength, headWidth) : super() {
     // dir is assumed to be normalized
 
@@ -27,7 +29,8 @@ class ArrowHelper extends Object3D {
 
     if (_lineGeometry == null) {
       _lineGeometry = BufferGeometry();
-      _lineGeometry.setAttribute('position', Float32BufferAttribute(Float32Array.from([0, 0, 0, 0, 1, 0]), 3, false));
+      _lineGeometry.setAttribute(
+          'position', Float32BufferAttribute(positionArray = Float32Array.from([0, 0, 0, 0, 1, 0]), 3, false));
 
       _coneGeometry = CylinderGeometry(0, 0.5, 1, 5, 1);
       _coneGeometry.translate(0, -0.5, 0);
@@ -88,5 +91,15 @@ class ArrowHelper extends Object3D {
       cone.copy(source.cone, false);
     }
     return this;
+  }
+
+  @override
+  void dispose() {
+    positionArray?.dispose();
+
+    line.dispose();
+    cone.dispose();
+
+    super.dispose();
   }
 }

--- a/lib/three3d/helpers/axes_helper.dart
+++ b/lib/three3d/helpers/axes_helper.dart
@@ -72,7 +72,7 @@ class AxesHelper extends LineSegments {
 
   @override
   void dispose() {
-    geometry!.dispose();
+    geometry?.dispose();
     material.dispose();
   }
 }

--- a/lib/three3d/loaders/file_loader.dart
+++ b/lib/three3d/loaders/file_loader.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:convert' as convert;
-import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -48,8 +47,7 @@ class FileLoader extends Loader {
     // Check if request is duplicate
 
     if (loading[url] != null) {
-      loading[url].add(
-          {"onLoad": onLoad, "onProgress": onProgress, "onError": onError});
+      loading[url].add({"onLoad": onLoad, "onProgress": onProgress, "onError": onError});
 
       return;
     }
@@ -143,8 +141,7 @@ class FileLoader extends Loader {
 
     loading[url] = [];
 
-    loading[url]
-        .add({"onLoad": onLoad, "onProgress": onProgress, "onError": onError});
+    loading[url].add({"onLoad": onLoad, "onProgress": onProgress, "onError": onError});
 
     var callbacks = loading[url];
 

--- a/lib/three3d/loaders/image_loader_for_app.dart
+++ b/lib/three3d/loaders/image_loader_for_app.dart
@@ -1,6 +1,5 @@
 import 'dart:isolate';
 import 'dart:io';
-import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;

--- a/lib/three3d/math/matrix3.dart
+++ b/lib/three3d/math/matrix3.dart
@@ -308,4 +308,8 @@ class Matrix3 {
   Map<String, dynamic> toJson() {
     return {'elements': elements};
   }
+
+  void dispose() {
+    elements.dispose();
+  }
 }

--- a/lib/three3d/math/matrix4.dart
+++ b/lib/three3d/math/matrix4.dart
@@ -827,4 +827,8 @@ class Matrix4 {
     print('three.Matrix4: .getInverse() has been removed. Use matrixInv.copy( matrix ).invert(); instead.');
     return copy(matrix).invert();
   }
+
+  void dispose() {
+    elements.dispose();
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.0"
   convert:
     dependency: transitive
     description:
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.6.5"
   lints:
     dependency: "direct dev"
     description:
@@ -204,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.14"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
@@ -228,10 +228,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.8.2"
   petitparser:
     dependency: transitive
     description:
@@ -305,10 +305,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.4.16"
   typed_data:
     dependency: transitive
     description:
@@ -350,5 +350,5 @@ packages:
     source: hosted
     version: "6.2.2"
 sdks:
-  dart: ">=2.19.0 <4.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,10 +105,9 @@ packages:
   flutter_gl:
     dependency: "direct main"
     description:
-      name: flutter_gl
-      sha256: de74c88f77228f47dd280e2092b50eb49fe1fc008de74047d195a27f2db0b491
-      url: "https://pub.dev"
-    source: hosted
+      path: "../flutter_gl/flutter_gl"
+      relative: true
+    source: path
     version: "0.0.21"
   flutter_gl_macos:
     dependency: transitive
@@ -217,13 +216,21 @@ packages:
     source: hosted
     version: "0.2.0"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
       url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
+  opentype_dart:
+    dependency: transitive
+    description:
+      name: opentype_dart
+      sha256: "4bd96aeed494289a87e92bde20afe60f59648dcef253c0a7159b65ffa23899dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   path:
     dependency: transitive
     description:
@@ -309,6 +316,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.16"
+  three_dart_jsm:
+    dependency: "direct overridden"
+    description:
+      path: "../three_dart_jsm"
+      relative: true
+    source: path
+    version: "0.0.10"
   typed_data:
     dependency: transitive
     description:
@@ -317,6 +331,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  typr_dart:
+    dependency: transitive
+    description:
+      name: typr_dart
+      sha256: e8aa717c1445ceccd77bd6ba471683c8e17a9b14797ac09db3bd52d6fbd2fe7b
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2"
   universal_html:
     dependency: "direct main"
     description:
@@ -351,4 +373,4 @@ packages:
     version: "6.2.2"
 sdks:
   dart: ">=2.18.0 <3.0.0"
-  flutter: ">=3.0.1"
+  flutter: ">=2.5.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   image: ^3.1.1
   flutter_gl: ^0.0.20
   crypto: ^3.0.1
+  meta:
   
   # opentype:
   #   git: git@github.com:wasabia/opentype.git
@@ -27,9 +28,11 @@ dependencies:
   # flutter_webgpu:
   #   path: ../flutter_webgpu
 
-# dependency_overrides:
-#   three_dart_jsm:
-#     path: ../three_dart_jsm
+dependency_overrides:
+  three_dart_jsm:
+    path: ../three_dart_jsm
+  flutter_gl:
+    path: ../flutter_gl/flutter_gl
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
There was serious memory leakage when you add and remove a lot of Object3d instances in a Scene. This greatly improves overal performance and memory usage.