### PR TITLE
points: Fix raycast threshold lookup

### DIFF
--- a/lib/three3d/objects/points.dart
+++ b/lib/three3d/objects/points.dart
@@ -34,7 +34,7 @@ class Points extends Object3D {
   void raycast(Raycaster raycaster, List<Intersection> intersects) {
     var geometry = this.geometry!;
     var matrixWorld = this.matrixWorld;
-    var threshold = raycaster.params["Points"].threshold;
+    var threshold = raycaster.params["Points"]["threshold"];
     var drawRange = geometry.drawRange;
 
     // Checking boundingSphere distance to ray


### PR DESCRIPTION
This fixes a broken lookup of the `threshold` value in the `Points` parameter map for the raycast function.