### PR TITLE
Flip Y in web (TextureLoader)

### DIFF
--- a/lib/three3d/loaders/image_loader.dart
+++ b/lib/three3d/loaders/image_loader.dart
@@ -43,7 +43,7 @@ class ImageLoader extends Loader {
       return cached;
     }
     // Note - see conditional import - 'image_loader_for_app.dart' or 'image_loader_for_web.dart'
-    final resp = await image_loader_web.ImageLoaderLoader.loadImage(url, flipY);
+    final resp = await ImageLoaderLoader.loadImage(url, flipY);
     onLoad(resp);
 
     return resp;

--- a/lib/three3d/loaders/image_loader.dart
+++ b/lib/three3d/loaders/image_loader.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:three_dart/three3d/loaders/cache.dart';
 import 'package:three_dart/three3d/loaders/loader.dart';
 import 'image_loader_for_app.dart' if (dart.library.js) 'image_loader_for_web.dart';

--- a/lib/three3d/loaders/image_loader.dart
+++ b/lib/three3d/loaders/image_loader.dart
@@ -3,8 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:three_dart/three3d/loaders/cache.dart';
 import 'package:three_dart/three3d/loaders/loader.dart';
-import 'image_loader_for_app.dart' as image_loader_app;
-import 'image_loader_for_web.dart' as image_loader_web;
+import 'image_loader_for_app.dart' if (dart.library.js) 'image_loader_for_web.dart';
 
 class ImageLoader extends Loader {
   ImageLoader(manager) : super(manager) {
@@ -43,9 +42,8 @@ class ImageLoader extends Loader {
 
       return cached;
     }
-    final resp = kIsWeb
-        ? await image_loader_web.ImageLoaderLoader.loadImage(url, flipY)
-        : await image_loader_app.ImageLoaderLoader.loadImage(url, flipY);
+    // Note - see conditional import - 'image_loader_for_app.dart' or 'image_loader_for_web.dart'
+    final resp = await image_loader_web.ImageLoaderLoader.loadImage(url, flipY);
     onLoad(resp);
 
     return resp;

--- a/lib/three3d/loaders/image_loader.dart
+++ b/lib/three3d/loaders/image_loader.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:three_dart/three3d/loaders/cache.dart';
 import 'package:three_dart/three3d/loaders/loader.dart';
-import 'image_loader_for_app.dart' if (dart.library.js) 'image_loader_for_web.dart';
+import 'image_loader_for_app.dart' as image_loader_app;
+import 'image_loader_for_web.dart' as image_loader_web;
 
 class ImageLoader extends Loader {
   ImageLoader(manager) : super(manager) {
@@ -41,8 +43,9 @@ class ImageLoader extends Loader {
 
       return cached;
     }
-
-    final resp = await ImageLoaderLoader.loadImage(url, flipY);
+    final resp = kIsWeb
+        ? await image_loader_web.ImageLoaderLoader.loadImage(url, flipY)
+        : await image_loader_app.ImageLoaderLoader.loadImage(url, flipY);
     onLoad(resp);
 
     return resp;

--- a/lib/three3d/loaders/image_loader_for_web.dart
+++ b/lib/three3d/loaders/image_loader_for_web.dart
@@ -4,6 +4,7 @@ import 'dart:html' as html;
 
 class ImageLoaderLoader {
   // flipY 在web环境下 忽略
+  // in web the flipping is done when rendering the texture, rather than when loading the texture
   static Future<html.ImageElement> loadImage(url, flipY, {Function? imageDecoder}) {
     var completer = Completer<html.ImageElement>();
     var imageDom = html.ImageElement();

--- a/lib/three3d/loaders/texture_loader.dart
+++ b/lib/three3d/loaders/texture_loader.dart
@@ -30,6 +30,7 @@ class TextureLoader extends Loader {
     // } else {
     //   texture = DataTexture(null, null, null,null, null, null,null, null, null, null, null, null);
     // }
+    texture.flipY = flipY;
 
     var loader = ImageLoader(manager);
     loader.setCrossOrigin(crossOrigin);

--- a/lib/three3d/loaders/texture_loader.dart
+++ b/lib/three3d/loaders/texture_loader.dart
@@ -22,7 +22,7 @@ class TextureLoader extends Loader {
   }
 
   @override
-  load(url, Function onLoad, [Function? onProgress, Function? onError]) {
+  Future<Texture> load(url, Function onLoad, [Function? onProgress, Function? onError]) {
     Texture texture;
 
     // if(kIsWeb) {


### PR DESCRIPTION
Setting `TextureLoader.flipY` had an effect in mobile apps, but had no effect web apps.

Also, texture loader defaults to flipY = false, while textures defaults to flipY = true. So I was having flipped images in web compared to what they looked like on iOS and android. So when I noticed flipY in the texture loader I tried that but it had no effect.

---

I would recommend removing flipY from `TextureLoader` - and recommend looking into a way to flip images on the GPU step rather than the image loading step. From what I can tell, the GPU step is how threeJS does it, and when it's in the loading step it's confusing that in some situations it flips while loading and others the flipping happens at a later step (web vs. mobile).